### PR TITLE
cli: add version command to cli config engine

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,9 +8,27 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
+  version = "v0.0.1"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
@@ -22,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4987caf4f31af6bbfc9cdaba5b867026538bc314ebb899739d596cf6edbdab1f"
+  inputs-digest = "f98acac1e7f1748a347a82acb61c2837aa1951f23967fe65e75c09ba46e4897f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,3 +24,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.1.4"
+
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  version = "0.0.1"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/pagarme/warp-pipe/cmd/version"
+	"github.com/pagarme/warp-pipe/config"
+)
+
+var root *cobra.Command
+
+func init() {
+
+	root = &cobra.Command{
+		Use:   config.AppName,
+		Short: config.AppShortDescription,
+		Long:  "",
+	}
+
+	root.AddCommand(version.New())
+}
+
+// Execute executes root command
+func Execute() error {
+	return root.Execute()
+}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,20 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/pagarme/warp-pipe/config"
+)
+
+// New returns a version command
+func New() *cobra.Command {
+
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show the version",
+		Long:  "",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Println("version:", config.AppVersion)
+		},
+	}
+}

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,22 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/pagarme/warp-pipe/config"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CmdVersion(t *testing.T) {
+
+	buf := &bytes.Buffer{}
+	versionCmd := New()
+	versionCmd.SetOutput(buf)
+	out := versionCmd.OutOrStdout()
+	require.Equal(t, buf, out)
+	err := versionCmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("version: %s\n", config.AppVersion), buf.String())
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,15 @@
+package config
+
+// Defaults
+const (
+	// AppVersion app version
+	AppVersion = "0.0.1"
+	// AppName app name
+	AppName = "warp-pipe"
+	// AppShortDescription command line short description
+	AppShortDescription = "Golang tools to handle postgres logical replication slots"
+	// ConfigEnvPrefix prefix for app env vars
+	ConfigEnvPrefix = "WP"
+	// ConfigFileType config filetype
+	ConfigFileType = "yaml"
+)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   test:
-    image: warp-pipe/test:latest
+    image: warp-pipe/golang:1.9.2-stretch
     volumes:
       - type: bind
         source: .
@@ -11,4 +11,4 @@ services:
         source: ${GOPATH}/pkg/linux_amd64
         target: /go/pkg/linux_amd64
     working_dir: /go/src/github.com/pagarme/warp-pipe
-    command: go test -v
+    command: go test -v ./...

--- a/main.go
+++ b/main.go
@@ -1,12 +1,21 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/pagarme/warp-pipe/cmd"
+)
 
 func sample() string {
 	return "sample"
 }
 
 func main() {
+
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
+
 	fmt.Println("Warp Pipe Project")
 	fmt.Println(sample())
 }


### PR DESCRIPTION
Add initial support for a CLI config engine with a first command called version. 

Usage: warp-pipe version.

Tks @jonatasnona and @drrzmr